### PR TITLE
fix booster reroll joker and deck interaction thing

### DIFF
--- a/backs.lua
+++ b/backs.lua
@@ -40,9 +40,7 @@ SMODS.Back {
     check_for_unlock = function(self, args)
         return args.type == 'discover_amount' and args.amount >= 160
     end,
-    apply = function(self, back)
-        G.GAME.modifiers.can_reroll_booster = true
-    end
+    --functionality is now stored in booster-reroll.toml, modifier is still functional however
 }
 ----------------------------------------------
 ------------MOD CODE END----------------------

--- a/joker.lua
+++ b/joker.lua
@@ -161,12 +161,7 @@ SMODS.Joker {
 	loc_vars = function(self, info_queue, card)
         return {}
     end,
-    add_to_deck = function(self, card, from_debuff)
-		G.GAME.modifiers.can_reroll_booster = true
-    end,
-    remove_from_deck = function(self, card, from_debuff)
-		G.GAME.modifiers.can_reroll_booster = false
-    end
+	--functionality is now stored in booster-reroll.toml, modifier is still functional however
 }
 
 ----------------------------------------------

--- a/lovely/booster_reroll.toml
+++ b/lovely/booster_reroll.toml
@@ -20,7 +20,7 @@ payload = '''
                         {n=G.UIT.R,config={minh =0.2}, nodes={}},
                         {n=G.UIT.R,config={align = "tm",padding = 0.2, minh = 1.2, minw = 1.8, r=0.15,colour = G.C.GREY, one_press = true, button = 'skip_booster', hover = true,shadow = true, func = 'can_skip_booster'}, nodes = {
                             {n=G.UIT.T, config={text = localize('b_skip'), scale = 0.5, colour = G.C.WHITE, shadow = true, focus_args = {button = 'y', orientation = 'bm'}, func = 'set_button_pip'}}}}}}}}}}}}
-        if G.GAME.modifiers.can_reroll_booster then
+        if G.GAME.modifiers.can_reroll_booster or next(SMODS.find_card("j_pok_recyclist")) or (G.GAME and G.GAME.selected_back.effect.center.key == "b_pok_recycling_deck") then
             return t2
         else
         return t


### PR DESCRIPTION
the one joker no longer kills booster rerolling anymore 

i just made the joker and deck hardcoded in the check for if you can reroll booster but the modifier is also still there and supported